### PR TITLE
Fix buffer and async event arg handle leaks

### DIFF
--- a/Stack/Core/Stack/Tcp/TcpChannel.cs
+++ b/Stack/Core/Stack/Tcp/TcpChannel.cs
@@ -370,14 +370,16 @@ namespace Opc.Ua.Bindings
                         error = ServiceResult.Create(StatusCodes.BadConnectionClosed, "The socket was closed by the remote application.");
                     }
 
-                    HandleWriteComplete(e.UserToken, e.BytesTransferred, error);
+                    HandleWriteComplete((BufferCollection) e.BufferList, e.UserToken, e.BytesTransferred, error);
                 }
                 catch (Exception ex)
                 {     
                     error = ServiceResult.Create(ex, StatusCodes.BadTcpInternalError, "Unexpected error during write operation.");
-                    HandleWriteComplete(e.UserToken, e.BytesTransferred, error);
+                    HandleWriteComplete((BufferCollection)e.BufferList, e.UserToken, e.BytesTransferred, error);
                 }
             }
+
+            e.Dispose();
         }
 
         /// <summary>
@@ -401,13 +403,15 @@ namespace Opc.Ua.Bindings
                         error = ServiceResult.Create(StatusCodes.BadConnectionClosed, args.SocketError.ToString());
                     }
 
-                    HandleWriteComplete(state, args.BytesTransferred, error);
+                    args.Dispose();
+                    HandleWriteComplete(null, state, args.BytesTransferred, error);
                 }
             }
             catch (Exception ex)
             {     
                 error = ServiceResult.Create(ex, StatusCodes.BadTcpInternalError, "Unexpected error during write operation.");
-                HandleWriteComplete(state, args.BytesTransferred, error);
+                args.Dispose();
+                HandleWriteComplete(null, state, args.BytesTransferred, error);
             }
         }
 
@@ -432,21 +436,27 @@ namespace Opc.Ua.Bindings
                         error = ServiceResult.Create(StatusCodes.BadConnectionClosed, args.SocketError.ToString());
                     }
 
-                    HandleWriteComplete(state, args.BytesTransferred, error);
+                    args.Dispose();
+                    HandleWriteComplete(buffers, state, args.BytesTransferred, error);
                 }
             }
             catch (Exception ex)
             {
                 error = ServiceResult.Create(ex, StatusCodes.BadTcpInternalError, "Unexpected error during write operation.");
-                HandleWriteComplete(state, args.BytesTransferred, error);
+                args.Dispose();
+                HandleWriteComplete(buffers, state, args.BytesTransferred, error);
             }
         }
         
         /// <summary>
         /// Called after a write operation completes.
         /// </summary>
-        protected virtual void HandleWriteComplete(object state, int bytesWritten, ServiceResult result)
+        protected virtual void HandleWriteComplete(BufferCollection buffers, object state, int bytesWritten, ServiceResult result)
         {
+            if (buffers != null)
+            {
+                buffers.Release(BufferManager, "WriteOperation");
+            }
         }
         
         /// <summary>

--- a/Stack/Core/Stack/Tcp/TcpClientChannel.cs
+++ b/Stack/Core/Stack/Tcp/TcpClientChannel.cs
@@ -649,7 +649,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Called when a write operation completes.
         /// </summary>
-        protected override void HandleWriteComplete(object state, int bytesWritten, ServiceResult result)
+        protected override void HandleWriteComplete(BufferCollection buffers, object state, int bytesWritten, ServiceResult result)
         {
             lock (DataLock)
             {
@@ -660,10 +660,11 @@ namespace Opc.Ua.Bindings
                     if (ServiceResult.IsBad(result))
                     {
                         operation.Fault(new ServiceResult(StatusCodes.BadSecurityChecksFailed, result));
-                        return;
                     }
                 }
             }
+
+            base.HandleWriteComplete(buffers, state, bytesWritten, result);
         }
 
         /// <summary>

--- a/Stack/Core/Stack/Tcp/TcpListener.cs
+++ b/Stack/Core/Stack/Tcp/TcpListener.cs
@@ -333,6 +333,10 @@ namespace Opc.Ua.Bindings
                 {
                     Utils.Trace(ex, "Unexpected error accepting a new connection.");
                 }
+                finally
+                {
+                    e.Dispose();
+                }
 
                 // go back and wait for the next connection.
                 try

--- a/Stack/Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Core/Stack/Tcp/TcpMessageSocket.cs
@@ -366,6 +366,10 @@ namespace Opc.Ua.Bindings
                     Utils.Trace(ex, "Unexpected error during OnReadComplete,");
                     error = ServiceResult.Create(ex, StatusCodes.BadTcpInternalError, ex.Message);
                 }
+                finally
+                {
+                    e.Dispose();
+                }
 
                 if (ServiceResult.IsBad(error))
                 {                
@@ -522,10 +526,13 @@ namespace Opc.Ua.Bindings
                         BufferManager.UnlockBuffer(m_receiveBuffer);
                         throw ServiceResultException.Create(StatusCodes.BadTcpInternalError, null, args.SocketError.ToString());
                     }
+
+                    args.Dispose();
                 }
             }
             catch (Exception ex)
             {
+                args.Dispose();
                 BufferManager.UnlockBuffer(m_receiveBuffer);
                 throw ServiceResultException.Create(StatusCodes.BadTcpInternalError, ex, "BeginReceive failed.");
             }


### PR DESCRIPTION
Buffers were not released and caused oom after a while.  Also, SocketAsyncEventArgs must be disposed as they contain socket file handles.